### PR TITLE
Enforce locally nameless convention

### DIFF
--- a/src/core/sign.ml
+++ b/src/core/sign.ml
@@ -99,14 +99,14 @@ let link : t -> unit = fun sign ->
       match unfold t with
       | Db _
       | Type
-      | Kind -> t
+      | Kind
+      | Vari _ -> t
       | Symb s -> mk_Symb(link_symb s)
-      | Prod(a,(n,b)) -> mk_Prod(link_term a, (n, link_term b))
-      | Abst(a,(n,b)) -> mk_Abst(link_term a, (n, link_term b))
-      | LLet(a,t,(n,b)) -> mk_LLet(link_term a, link_term t, (n, link_term b))
+      | Prod(a,b) -> mk_Prod(link_term a, binder link_term b)
+      | Abst(a,b) -> mk_Abst(link_term a, binder link_term b)
+      | LLet(a,t,b) -> mk_LLet(link_term a, link_term t, binder link_term b)
       | Appl(a,b)   -> mk_Appl(link_term a, link_term b)
       | Patt(i,n,ts)-> mk_Patt(i, n, Array.map link_term ts)
-      | Vari _ -> assert false
       | Meta _ -> assert false
       | Plac _ -> assert false
       | Wild -> assert false
@@ -171,15 +171,15 @@ let unlink : t -> unit = fun sign ->
   let rec unlink_term t =
     match unfold t with
     | Symb s -> unlink_sym s
-    | Prod(a,(_,b))
-    | Abst(a,(_,b)) -> unlink_term a; unlink_term b
-    | LLet(a,t,(_,b)) -> unlink_term a; unlink_term t; unlink_term b
+    | Prod(a,b)
+    | Abst(a,b) -> unlink_term a; unlink_term (snd(unbind b))
+    | LLet(a,t,b) -> unlink_term a; unlink_term t; unlink_term (snd(unbind b))
     | Appl(a,b) -> unlink_term a; unlink_term b
     | Meta _ -> assert false
     | Plac _ -> assert false
     | Wild   -> assert false
     | TRef _ -> assert false
-    | Vari _ -> assert false
+    | Vari _
     | Patt _
     | Db _
     | Type
@@ -278,14 +278,14 @@ let read : string -> t = fun fname ->
     match unfold t with
     | Type
     | Kind
-    | Db _ -> ()
+    | Db _
+    | Vari _ -> ()
     | Symb s -> shallow_reset_sym s
-    | Prod(a,(_,b))
-    | Abst(a,(_,b)) -> reset_term a; reset_term b
-    | LLet(a,t,(_,b)) -> reset_term a; reset_term t; reset_term b
+    | Prod(a,b)
+    | Abst(a,b) -> reset_term a; reset_term (snd (unbind b))
+    | LLet(a,t,b) -> reset_term a; reset_term t; reset_term (snd(unbind b))
     | Appl(a,b) -> reset_term a; reset_term b
     | Patt(_,_,ts) -> Array.iter reset_term ts
-    | Vari _ -> assert false
     | TRef _ -> assert false
     | Wild -> assert false
     | Meta _ -> assert false

--- a/src/core/term.mli
+++ b/src/core/term.mli
@@ -45,6 +45,10 @@ type mbinder_info
 
 val binder_name : binder_info -> string
 
+(** Type for binders. *)
+type binder
+type mbinder
+
 (** Representation of a term (or types) in a general sense. Values of the type
     are also used, for example, in the representation of patterns or rewriting
     rules. Specific constructors are included for such applications,  and they
@@ -68,10 +72,6 @@ type term = private
   | TRef of term option ref (** Reference cell (used in surface matching). *)
   | LLet of term * term * binder
   (** [LLet(a, t, u)] is [let x : a ≔ t in u] (with [x] bound in [u]). *)
-
-(** Type for binders. *)
-and binder = binder_info * term
-and mbinder = mbinder_info * term
 
 (** {b NOTE} that a wildcard "_" of the concrete (source code) syntax may have
     a different representation depending on the context. For instance, the


### PR DESCRIPTION
The PR consists of
- Abstracted away the type of binders of term.mli to enfore locally nameless convention
- Substitution performed from the Term interface are always closed (no shift needed)
- Some substitutions (internal to Term) are open so the general substitution function is parameterized by a boolean to identify the open term case

The term processing in sign.ml is not optimal since it requires term unbind/bind operations while it just affects leaves (Symbols). If it showed to be too inefficient (which is afaik not the case), we could add a term iterator in the Term signature.